### PR TITLE
fix locale interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,10 +42,10 @@ declare module "react-date-object" {
 
   export type Locale = {
     name: string;
-    months: [string[]];
-    weekDays: [string[]];
+    months: Array<string[]>;
+    weekDays: Array<string[]>;
     digits: string[];
-    meridiems: [string[]];
+    meridiems: Array<string[]>;
   };
 
   export type Month = {


### PR DESCRIPTION
```
const locale = {
  monthes = [
    ["january', 'jan']
  ]
} 
```
I think this interface is following. 
```
const Locale = {
 monthes: [string[], string[]]
}
```
or
```
const Locale = {
  monthes: Array<string[]>
}
```