### PR TITLE
Add type declarations for new Julian calendar in date-object.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -543,7 +543,7 @@ declare module "react-date-object/calendars/indian" {
   export default indian;
 }
 
-declare module "date-object/calendars/cjs/julian" {
+declare module "react-date-object/calendars/julian" {
   const julian: Calendar;
 
   export = julian;

--- a/index.d.ts
+++ b/index.d.ts
@@ -543,6 +543,12 @@ declare module "react-date-object/calendars/indian" {
   export default indian;
 }
 
+declare module "date-object/calendars/cjs/julian" {
+  const julian: Calendar;
+
+  export = julian;
+}
+
 declare module "react-date-object/locales/gregorian_en" {
   import type { Locale } from "react-date-object";
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -544,6 +544,8 @@ declare module "react-date-object/calendars/indian" {
 }
 
 declare module "react-date-object/calendars/julian" {
+  import type { Calendar } from "react-date-object";
+
   const julian: Calendar;
 
   export = julian;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-date-object",
-  "version": "2.1.7",
+  "version": "2.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-date-object",
-      "version": "2.1.7",
+      "version": "2.1.9",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.23.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-object",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "JavaScript library for working with Date and Time in different calendars and locals",
   "main": "./dist/index.js",
   "module": "./dist/index.module.js",


### PR DESCRIPTION
I am using react-multi-date-picker which relies on this typed wrapper for date-object. I added the Julian calendar to date-object but it requires some workarounds to use it in react-multi-date-picker because react-date-object has not been updated and rebuilt.

I added type declarations for the Julian calendar in date-object here.
